### PR TITLE
More flexible JcardSim configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ Note2 : you can add as many `local` or `remote` dependency as you want
 * javacard [Closure]
   * config [Closure] - object that holds build configuration **Required**
     * jckit [String] - path to the JavaCard SDK that is used if individual cap does not specify one. Optional if cap defines one, required otherwise. The path is relative to the module
+    * jcardSim [String|Map] - optional JcardSim dependency definition, requires addImplicitJcardSim=true
+    * addSurrogateJcardSimRepo [Boolean] - if true (default) the surrogate maven repo with JcardSim 3.0.4 is added
+    * addImplicitJcardSim [Boolean] - if true (default) the JcardSim is added to the test target by the plugin. If set to false user can specify own JcardSim dependency, such as: `jcardsim 'com.licel:jcardsim:3.0.4'`. 
+    * addImplicitJcardSimJunit [Boolean] - if true (default) the JcardSim dependency junit is added by the plugin.
     * logLevel [String] - log level of ant-javacard task ("VERBOSE","DEBUG","INFO","WARN","ERROR"). default : "INFO"
     * cap [Closure] - construct a CAP file **Required**
       * jckit [String] - path to the JavaCard SDK to be used for this CAP. *Optional if javacard defines one, required otherwise*

--- a/gradle-javacard/src/main/groovy/fr/bmartel/javacard/extension/Config.groovy
+++ b/gradle-javacard/src/main/groovy/fr/bmartel/javacard/extension/Config.groovy
@@ -39,6 +39,11 @@ class Config {
      */
     String jckit
 
+    Object jcardSim
+    boolean addSurrogateJcardSimRepo = true
+    boolean addImplicitJcardSim = true
+    boolean addImplicitJcardSimJunit = true
+
     /**
      * log level to set to "VERBOSE","DEBUG","INFO","WARN" or "ERROR", default is "INFO"
      */
@@ -64,6 +69,22 @@ class Config {
 
     void logLevel(String logLevel) {
         this.logLevel = logLevel
+    }
+
+    void jcardSim(Object jcardSim) {
+        this.jcardSim = jcardSim
+    }
+
+    void addSurrogateJcardSimRepo(Boolean addIt) {
+        this.addSurrogateJcardSimRepo = addIt
+    }
+
+    void addImplicitJcardSim(Boolean addIt) {
+        this.addImplicitJcardSim = addIt
+    }
+
+    void addImplicitJcardSimJunit(Boolean addIt) {
+        this.addImplicitJcardSimJunit = addIt
     }
 
     /**


### PR DESCRIPTION
Hi! Thanks for this awesome gradle plugin!

I've been working with it for a while and I find useful to be able to change the JcardSim dependency included in the tests. 

This PR adds few options to the `extension.configuration`

Namely:

* jcardSim [String|Map] - optional JcardSim dependency definition, requires addImplicitJcardSim=true
* addSurrogateJcardSimRepo [Boolean] - if true (default) the surrogate maven repo with JcardSim 3.0.4 is added
* addImplicitJcardSim [Boolean] - if true (default) the JcardSim is added to the test target by the plugin. If set to false user can specify own JcardSim dependency, such as: jcardsim 'com.licel:jcardsim:3.0.4'.
* addImplicitJcardSimJunit [Boolean] - if true (default) the JcardSim dependency junit is added by the plugin.

With this I can disable the repo being added or include different version of the JCardSim.

Please take a look and let me know if this is OK for you. Thanks!