### PR TITLE
finding sources automatically by default - from the existing source sets

### DIFF
--- a/gradle-javacard/src/main/groovy/fr/bmartel/javacard/JavaCardBuildTask.groovy
+++ b/gradle-javacard/src/main/groovy/fr/bmartel/javacard/JavaCardBuildTask.groovy
@@ -244,36 +244,43 @@ class JavaCardBuildTask extends DefaultTask {
     }
 
     /**
+     * Finds first available source set match
+     * @param capItem
+     * @return
+     */
+    def findDefaultSources(capItem){
+        if (capItem.findSources) {
+            def folderFound = false
+            def folderIdx = 0
+            for(curSrcDir in project.sourceSets.main.java.srcDirs){
+                if (curSrcDir.exists() && (capItem.defaultSources || folderIdx > 0)) {
+                    folderFound = true
+                    capItem.sources = curSrcDir
+                    break
+                }
+                folderIdx += 1
+            }
+
+            if (!folderFound){
+                throw new InvalidUserDataException('Applet sources not found : ' + project.sourceSets.main.java.srcDirs[0])
+            }
+
+        } else {
+            def srcIndex = capItem.defaultSources ? 0 : project.sourceSets.main.java.srcDirs.size() - 1;
+            capItem.sources = project.sourceSets.main.java.srcDirs[srcIndex]
+        }
+
+        logger.debug('update source path to ' + capItem.sources)
+    }
+
+    /**
      * Update output file path inclusing cap, exp and jca
      *
      * @param capItem cap object
      */
     def updateOutputFilePath(capItem) {
         if (!capItem.sources?.trim()) {
-
-            // Finding first source match
-            if (capItem.findSources) {
-                def folderFound = false
-                def folderIdx = 0
-                for(curSrcDir in project.sourceSets.main.java.srcDirs){
-                    if (curSrcDir.exists() && (capItem.defaultSources || folderIdx > 0)) {
-                        folderFound = true
-                        capItem.sources = curSrcDir
-                        break
-                    }
-                    folderIdx += 1
-                }
-
-                if (!folderFound){
-                    throw new InvalidUserDataException('Applet sources not found : ' + project.sourceSets.main.java.srcDirs[0])
-                }
-
-            } else {
-                def srcIndex = capItem.defaultSources ? 0 : project.sourceSets.main.java.srcDirs.size() - 1;
-                capItem.sources = project.sourceSets.main.java.srcDirs[srcIndex]
-            }
-
-            logger.debug('update source path to ' + capItem.sources)
+            findDefaultSources(capItem);
         }
 
         File file = new File(capItem.output);

--- a/gradle-javacard/src/main/groovy/fr/bmartel/javacard/extension/Cap.groovy
+++ b/gradle-javacard/src/main/groovy/fr/bmartel/javacard/extension/Cap.groovy
@@ -42,6 +42,16 @@ class Cap {
     String sources
 
     /**
+     * If true the sources are determined automatically. The first existing source dir in source sets is taken.
+     */
+    boolean findSources = true
+
+    /**
+     * if true the first source dir from the source set is used. Otherwise the most recet (last).
+     */
+    boolean defaultSources = true
+
+    /**
      * path to pre-compiled class files to be assembled into a CAP file. If both classes and sources are specified,
      * compiled class files will be put to classes folder, which is created if missing.
      */
@@ -126,6 +136,14 @@ class Cap {
 
     void sources(String path) {
         this.sources = path
+    }
+
+    void findSources(Boolean findSources) {
+        this.findSources = findSources
+    }
+
+    void defaultSources(Boolean defaultSources) {
+        this.defaultSources = defaultSources
     }
 
     void packageName(String packageName) {


### PR DESCRIPTION
Hi!

similarly to #2 I find useful to auto-detect sources for the CAP compilation.

The thing is when the gradle project has somehow different project layout and the sourcesets are changed, e.g., as below, the `project.sourceSets.main.java.srcDirs[0]` still points to the original directory. 

```groovy
sourceSets {
    main {
        java {
            srcDir 'project/src/main/java'
        }
    }
}
```

My improvement adds few more switches so it iterates over source dirs (if findSources is enabled) and picks the first existing source directory. 

This helped me a lot not to duplicate source dir settings as it successfully detects source set dir defined from the project.

Thanks for consideration!
 